### PR TITLE
Allow for credential creation in a cross-origin iframe

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1645,9 +1645,17 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
 1. Assert: <code>|options|.{{CredentialCreationOptions/publicKey}}</code> is present.
 
-1. If <var ignore>sameOriginWithAncestors</var> is [FALSE], throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If <var ignore>sameOriginWithAncestors</var> is [FALSE]:
 
-    Note: This "sameOriginWithAncestors" restriction aims to address a tracking concern raised in [Issue #1336](https://github.com/w3c/webauthn/issues/1336). This may be revised in future versions of this specification.
+    1. If the [=relevant global object=], as determined by the calling
+        {{CredentialsContainer/create()}} implementation, does not have
+        [=transient activation=]:
+
+        Note: **TODO**: Do we have access to the relevant global object here, or does this have to be computed in webappsec-credential-management?
+
+        1. Throw a "{{NotAllowedError}}" {{DOMException}}.
+
+    1. [=Consume user activation=] of the [=relevant global object=].
 
 1. Let |options| be the value of <code>|options|.{{CredentialCreationOptions/publicKey}}</code>.
 
@@ -3706,17 +3714,18 @@ Note: The {{UserVerificationRequirement}} enumeration is deliberately not refere
 
 ## Permissions Policy integration ## {#sctn-permissions-policy}
 
-This specification defines one [=policy-controlled feature=] identified by
-the feature-identifier token "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>".
-Its [=default allowlist=] is '<code>self</code>'. [[!Permissions-Policy]]
+This specification defines two [=policy-controlled features=] identified by
+the feature-identifier tokens "<code><dfn data-lt="publickey-credentials-create-feature" export>publickey-credentials-create</dfn></code>"
+and "<code><dfn data-lt="publickey-credentials-get-feature" export>publickey-credentials-get</dfn></code>".
+Their [=default allowlists=] are both '<code>self</code>'. [[!Permissions-Policy]]
 
 A {{Document}}'s [=Document/permissions policy=] determines whether any content in that <a href="https://html.spec.whatwg.org/multipage/dom.html#documents">document</a> is
-[=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via
-<code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>.
+[=allowed to use|allowed to successfully invoke=] the [=Web Authentication API=], i.e., via <code><a idl for="CredentialsContainer" lt="create()">navigator.credentials.create({publicKey:..., ...})</a></code> or
+<code><a idl for="CredentialsContainer" lt="get()">navigator.credentials.get({publicKey:..., ...})</a></code>
 If disabled in any document, no content in the document will be [=allowed to use=]
 the foregoing methods: attempting to do so will [return an error](https://www.w3.org/2001/tag/doc/promises-guide#errors).
 
-Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal method=] does not have such access since it is invoked [=in parallel=] by {{CredentialsContainer}}'s <a abstract-op>Request a `Credential`</a> abstract operation [[!CREDENTIAL-MANAGEMENT-1]].
+Note: Algorithms specified in [[!CREDENTIAL-MANAGEMENT-1]] perform the actual permissions policy evaluation. This is because such policy evaluation needs to occur when there is access to the [=current settings object=]. The {{PublicKeyCredential/[[Create]](origin, options, sameOriginWithAncestors)}} and {{PublicKeyCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}} [=internal methods=] does not have such access since they are invoked [=in parallel=] by {{CredentialsContainer}}'s <a abstract-op>Create a `Credential`</a> and <a abstract-op>Request a `Credential`</a> abstract operations [[!CREDENTIAL-MANAGEMENT-1]].
 
 
 


### PR DESCRIPTION
See https://github.com/w3c/webauthn/issues/1656

This PR adds the ability to call `navigator.credentials.create()` in a cross-origin
iframe (more exactly, a frame that is not same-origin with its ancestor chain),
as long as the following conditions are met:

- The iframe has a `publickey-credentials-create-feature` permission policy
- The iframe has a [user activation](https://html.spec.whatwg.org/multipage/interaction.html#tracking-user-activation)

It has a corresponding PR on the credential management spec; see [TODO]